### PR TITLE
Count Limit to Files + Returns More Media Data

### DIFF
--- a/android/src/main/java/com/photopicker/PhotoPickerConstants.java
+++ b/android/src/main/java/com/photopicker/PhotoPickerConstants.java
@@ -18,5 +18,11 @@ public class PhotoPickerConstants {
     public static final String IMAGE_ONLY = "ImageOnly";
     public static final String VIDEO_ONLY = "VideoOnly";
 
-
+    // Attachment object
+    public static final String ATTACHMENTS = "attachments";
+    public static final String URI = "uri";
+    public static final String WIDTH = "width";
+    public static final String HEIGHT = "height";
+    public static final String SIZE = "size";
+    public static final String MIME = "mime";
 }

--- a/src/types/PhotoPickerTypes.ts
+++ b/src/types/PhotoPickerTypes.ts
@@ -9,6 +9,7 @@ export interface OptionsInterface {
   mediaType?: MediaTypes;
   mimeType?: string;
   multipleMedia?: boolean;
+  maxItems?: number;
 }
 
 export interface PhotoPickerInterface {


### PR DESCRIPTION
- Added property maxItems to set a limit when multiple media selection is true. 
- Rather than returning an array of uris, instead return an array of attachment objects. Attachment objects have the properties: uri, width, height, size, and mime.
- Refactored onActivityResult() function to minimize the number of nested if-statements. 
- Added new PhotoPickerConstants for the attachment object.